### PR TITLE
Ensure treetable ids are unique

### DIFF
--- a/bom/models.py
+++ b/bom/models.py
@@ -503,7 +503,8 @@ class PartRevision(models.Model):
 
     def indented(self, top_level_quantity=100):
         def indented_given_bom(bom, part_revision, parent_id=None, parent=None, qty=1, parent_qty=1, indent_level=0, subpart=None, reference='', do_not_load=False):
-            bom_item_id = (parent_id or '') + (str(part_revision.id) + '-dnl' if do_not_load else str(part_revision.id))
+            # Create a (unique) item ID, used to relate the part to its parent/children in the indented view
+            bom_item_id = (f"{parent_id}-" if parent_id else '') + (str(part_revision.id) + '-dnl' if do_not_load else str(part_revision.id))
             extended_quantity = parent_qty * qty
             total_extended_quantity = top_level_quantity * extended_quantity
 


### PR DESCRIPTION
This PR fixes the issue described in #4, where items in a BOM weren't always correctly associated with their parent part (and some parts not displayed at all). The issue was that the ID associated with a part/subpart in the indented view was constructed with the ID of the parent, concatenated with the part's ID. However, this resulting integer ID could easily collide with other parts'/subparts' IDs
For instance, the part Neousys Power Cable (-) had ID 112125, from its ID 25 and parent 1121 (ID 1 and parent 112); while the TIMs Sub-Assembly also had ID 112125, from its ID 125 and parent 112. So the TIMs assembly's subparts were incorrectly listed under the Neousys negative cable.

A comparison of the first level deep of the GC Chassis Assembly BOM is shown below, before and after the fix
![broken_bom](https://user-images.githubusercontent.com/20861036/219493427-d2c1562d-3a5c-4db0-b871-867426d71813.png)
![correct_bom](https://user-images.githubusercontent.com/20861036/219493423-e2341462-2b31-4a5a-b936-a0c66e8b6bb3.png)

The fix was to insert a delimiter between the parent ID and current ID, to disambiguate the same sequence of numbers from different IDs
