### PR TITLE
NRE default value, clean up export options, add lead time wks

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.10]
+        python-version: [3.10.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.10.10]
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/bom/csv_headers.py
+++ b/bom/csv_headers.py
@@ -178,6 +178,7 @@ class SellerPartCSVHeaders(CSVHeaders):
         CSVHeader('nre_cost', name_options=['part_nre', 'part_nre_cost', 'nre', 'nre_cost', ]),
         CSVHeader('minimum_pack_quantity', name_options=['minimum_pack_quantity', 'mpq', 'part_mpq' ]),
         CSVHeader('lead_time_days', name_options=['lead_time_days', 'lead_time', 'lt']),
+        CSVHeader('lead_time_weeks', name_options=['lead_time_weeks', 'lead_time', 'ltw']),
     ]
 
 
@@ -267,6 +268,7 @@ class BOMFlatCSVHeaders(CSVHeaders):
         CSVHeader('order_qty', name_options=['part_order_qty', 'part_order_quantity', 'order_quantity', ]),
         CSVHeader('out_of_pocket_cost', name_options=['part_out_of_pocket_cost', 'cost', ]),
         CSVHeader('lead_time_days', name_options=['part_lead_time_days', ]),
+        CSVHeader('lead_time_weeks', name_options=['part_lead_time_weeks', ]),
     ]
 
 

--- a/bom/forms.py
+++ b/bom/forms.py
@@ -302,7 +302,7 @@ class SellerPartForm(forms.ModelForm):
         self.organization = kwargs.pop('organization', None)
         self.manufacturer_part = kwargs.pop('manufacturer_part', None)
         self.base_fields['unit_cost'] = forms.DecimalField(required=True, decimal_places=4, max_digits=17)
-        self.base_fields['nre_cost'] = forms.DecimalField(required=False, decimal_places=4, max_digits=17, label='NRE cost', initial=0.0)
+        self.base_fields['nre_cost'] = forms.DecimalField(required=True, decimal_places=4, max_digits=17, label='NRE cost', initial=0.0)
 
         instance = kwargs.get('instance')
         if instance:

--- a/bom/forms.py
+++ b/bom/forms.py
@@ -302,7 +302,7 @@ class SellerPartForm(forms.ModelForm):
         self.organization = kwargs.pop('organization', None)
         self.manufacturer_part = kwargs.pop('manufacturer_part', None)
         self.base_fields['unit_cost'] = forms.DecimalField(required=True, decimal_places=4, max_digits=17)
-        self.base_fields['nre_cost'] = forms.DecimalField(required=True, decimal_places=4, max_digits=17, label='NRE cost')
+        self.base_fields['nre_cost'] = forms.DecimalField(required=False, decimal_places=4, max_digits=17, label='NRE cost', initial=0.0)
 
         instance = kwargs.get('instance')
         if instance:

--- a/bom/helpers.py
+++ b/bom/helpers.py
@@ -1,7 +1,6 @@
 from bom import constants
 from bom.models import (
     Assembly,
-    AssemblySubparts,
     Manufacturer,
     ManufacturerPart,
     Organization,

--- a/bom/models.py
+++ b/bom/models.py
@@ -733,8 +733,8 @@ class SellerPart(models.Model, AsDictModel):
             'seller_link': self.link,
             'minimum_order_quantity': self.minimum_order_quantity,
             'nre_cost': self.nre_cost,
-            'lead_time_days': self.lead_time_days or 0,
-            'lead_time_weeks': ceil(self.lead_time_days / 7) if self.lead_time_days else 0,
+            'lead_time_days': self.lead_time_days,
+            'lead_time_weeks': ceil(self.lead_time_days / 7) if self.lead_time_days else None
         }
 
     @staticmethod

--- a/bom/models.py
+++ b/bom/models.py
@@ -721,7 +721,7 @@ class SellerPart(models.Model, AsDictModel):
         d = super().as_dict()
         d['unit_cost'] = self.unit_cost.amount
         d['nre_cost'] = self.nre_cost.amount
-        d['lead_time_weeks'] = ceil(self.lead_time_days / 7)
+        d['lead_time_weeks'] = ceil(self.lead_time_days / 7) if self.lead_time_days else None
         return d
 
     def as_dict_for_export(self):

--- a/bom/models.py
+++ b/bom/models.py
@@ -5,7 +5,6 @@ from math import ceil
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.core.cache import cache
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
@@ -722,6 +721,7 @@ class SellerPart(models.Model, AsDictModel):
         d = super().as_dict()
         d['unit_cost'] = self.unit_cost.amount
         d['nre_cost'] = self.nre_cost.amount
+        d['lead_time_weeks'] = ceil(self.lead_time_days / 7)
         return d
 
     def as_dict_for_export(self):
@@ -732,7 +732,9 @@ class SellerPart(models.Model, AsDictModel):
             'unit_cost': self.unit_cost,
             'seller_link': self.link,
             'minimum_order_quantity': self.minimum_order_quantity,
-            'nre_cost': self.nre_cost
+            'nre_cost': self.nre_cost,
+            'lead_time_days': self.lead_time_days or 0,
+            'lead_time_weeks': ceil(self.lead_time_days / 7) if self.lead_time_days else 0,
         }
 
     @staticmethod

--- a/bom/part_bom.py
+++ b/bom/part_bom.py
@@ -90,7 +90,7 @@ class PartBom(AsDictModel):
             return mps
         return [item.part.manufacturer_part for item in self.parts]
 
-    def as_dict(self, include_id=False):
+    def as_dict(self):
         d = super().as_dict()
         d['unit_cost'] = self.unit_cost.amount
         d['nre'] = self.nre_cost.amount
@@ -134,12 +134,13 @@ class PartBomItem(AsDictModel):
             logger.log(logging.INFO, '[part_bom.py] ' + str(err))
             return Money(0, self._currency)
 
-    def as_dict(self, include_id=False):
+    def as_dict(self):
         dict = super().as_dict()
         del dict['bom_id']
         return dict
 
     def as_dict_for_export(self):
+        seller_part_dict = self.seller_part.as_dict_for_export() if self.seller_part is not None else {}
         return {
             'part_number': self.part.full_part_number(),
             'quantity': self.quantity,
@@ -153,15 +154,9 @@ class PartBomItem(AsDictModel):
             'part_manufacturer_part_number': self.part.primary_manufacturer_part.manufacturer_part_number if self.part.primary_manufacturer_part is not None else '',
             'part_ext_qty': self.extended_quantity,
             'part_order_qty': self.order_quantity,
-            'part_seller': self.seller_part.seller.name if self.seller_part is not None else '',
-            'part_seller_link': self.seller_part.link if self.seller_part is not None else '',
-            'part_cost': self.seller_part.unit_cost if self.seller_part is not None else '',
-            'part_moq': self.seller_part.minimum_order_quantity if self.seller_part is not None else 0,
-            'part_nre': self.seller_part.nre_cost if self.seller_part is not None else 0,
             'part_ext_cost': self.extended_cost(),
             'part_out_of_pocket_cost': self.out_of_pocket_cost(),
-            'part_lead_time_days': self.seller_part.lead_time_days if self.seller_part is not None else 0,
-        }
+        } | seller_part_dict
 
     def manufacturer_parts_for_export(self):
         return [mp.as_dict_for_export() for mp in self.part.manufacturer_parts(exclude_primary=True)]

--- a/bom/templates/bom/components/bom-flat.html
+++ b/bom/templates/bom/components/bom-flat.html
@@ -30,10 +30,10 @@
                 {% endif %}
                 {% if part_revision %}
                     <li><a class="green-text text-lighten-1" href="{% url 'bom:part-revision-export-bom-flat' part_revision_id=part_revision.id %}">
-                        <i class="material-icons green-text text-lighten-1">cloud_download</i>Download CSV</a>
+                        <i class="material-icons green-text text-lighten-1">cloud_download</i>Download CSV (flat)</a>
                     </li>
                 {% else %}
-                    <li><a class="green-text text-lighten-1 disabled" href=""><i class="material-icons green-text text-lighten-1">cloud_download</i>Download CSV</a></li>
+                    <li><a class="green-text text-lighten-1 disabled" href=""><i class="material-icons green-text text-lighten-1">cloud_download</i>Download CSV (flat)</a></li>
                 {% endif %}
             </ul>
         {% endif %}

--- a/bom/templates/bom/components/bom-flat.html
+++ b/bom/templates/bom/components/bom-flat.html
@@ -32,12 +32,6 @@
                     <li><a class="green-text text-lighten-1" href="{% url 'bom:part-revision-export-bom-flat' part_revision_id=part_revision.id %}">
                         <i class="material-icons green-text text-lighten-1">cloud_download</i>Download CSV</a>
                     </li>
-                    <li><a class="green-text text-lighten-1" href="{% url 'bom:part-revision-export-bom-flat-sourcing' part_revision_id=part_revision.id %}">
-                        <i class="material-icons green-text text-lighten-1">cloud_download</i>Download CSV (sourcing)</a>
-                    </li>
-                    <li><a class="green-text text-lighten-1" href="{% url 'bom:part-revision-export-bom-flat-sourcing-detailed' part_revision_id=part_revision.id %}">
-                        <i class="material-icons green-text text-lighten-1">cloud_download</i>Download CSV (sourcing detailed)</a>
-                    </li>
                 {% else %}
                     <li><a class="green-text text-lighten-1 disabled" href=""><i class="material-icons green-text text-lighten-1">cloud_download</i>Download CSV</a></li>
                 {% endif %}

--- a/bom/templates/bom/components/bom-indented.html
+++ b/bom/templates/bom/components/bom-indented.html
@@ -40,12 +40,6 @@
                     <li><a class="green-text text-lighten-1" href="{% url 'bom:part-revision-export-bom' part_revision_id=part_revision.id %}">
                         <i class="material-icons green-text text-lighten-1">cloud_download</i>Download CSV</a>
                     </li>
-                    <li><a class="green-text text-lighten-1" href="{% url 'bom:part-revision-export-bom-sourcing' part_revision_id=part_revision.id %}">
-                        <i class="material-icons green-text text-lighten-1">cloud_download</i>Download CSV (sourcing)</a>
-                    </li>
-                    <li><a class="green-text text-lighten-1" href="{% url 'bom:part-revision-export-bom-sourcing-detailed' part_revision_id=part_revision.id %}">
-                        <i class="material-icons green-text text-lighten-1">cloud_download</i>Download CSV (sourcing detailed)</a>
-                    </li>
                 {% else %}
                     <li><a class="green-text text-lighten-1 disabled" href=""><i class="material-icons green-text text-lighten-1">cloud_download</i>Download CSV</a></li>
                 {% endif %}

--- a/bom/tests.py
+++ b/bom/tests.py
@@ -149,14 +149,14 @@ class TestBOM(TransactionTestCase):
     def test_part_revision_export_bom(self):
         (p1, p2, p3, p4) = create_some_fake_parts(organization=self.organization)
 
-        for part in [p1, p2, p3, p4]:
-            response = self.client.post(reverse('bom:part-revision-export-bom', kwargs={'part_id': part.latest().id}))
+        for part in [p1, p2, p3]:
+            response = self.client.post(reverse('bom:part-revision-export-bom', kwargs={'part_revision_id': part.latest().id}))
             self.assertEqual(response.status_code, 200)
 
     def test_part_revision_export_bom_flat(self):
         (p1, p2, p3, p4) = create_some_fake_parts(organization=self.organization)
 
-        for part in [p1, p2, p3, p4]:
+        for part in [p1, p2, p3]:
             response = self.client.post(reverse('bom:part-revision-export-bom-flat', kwargs={'part_revision_id': part.latest().id}))
             self.assertEqual(response.status_code, 200)
 

--- a/bom/tests.py
+++ b/bom/tests.py
@@ -19,7 +19,7 @@ from .helpers import (
     create_some_fake_parts,
     create_user_and_organization,
 )
-from .models import Manufacturer, ManufacturerPart, Part, PartClass, PartRevision, Seller, Subpart
+from .models import Part, PartClass, Seller, Subpart
 
 
 TEST_FILES_DIR = "bom/test_files"

--- a/bom/tests.py
+++ b/bom/tests.py
@@ -1,5 +1,5 @@
 import csv
-from re import finditer, search
+from re import finditer
 from unittest import skip
 
 from django.conf import settings
@@ -17,10 +17,9 @@ from .helpers import (
     create_some_fake_manufacturers,
     create_some_fake_part_classes,
     create_some_fake_parts,
-    create_some_fake_sellers,
     create_user_and_organization,
 )
-from .models import ManufacturerPart, Part, PartClass, Seller, SellerPart, Subpart
+from .models import Manufacturer, ManufacturerPart, Part, PartClass, PartRevision, Seller, Subpart
 
 
 TEST_FILES_DIR = "bom/test_files"
@@ -522,6 +521,22 @@ class TestBOM(TransactionTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue('error' in str(response.content))
         self.assertTrue('already in use' in str(response.content))
+
+    def test_unique_indented_part_ids(self):
+        org = self.organization
+        pc = PartClass(code=1, name="CoolName", organization=org)
+        pc.save()
+        p = Part(number_item=('A' * org.number_item_len), organization=org, number_class=pc)
+        p.save()
+        m = Manufacturer(name="MyMan", organization=org)
+        m.save()
+        mp = ManufacturerPart(part=p, manufacturer=m, manufacturer_part_number="A1234321")
+        mp.save()
+        p.primary_manufacturer_part = mp
+        p.save()
+        pr = PartRevision(part=p, revision="1")
+        pr.save()
+        print(pr)
 
     def test_create_part_no_manufacturer_part(self):
         (p1, p2, p3, p4) = create_some_fake_parts(organization=self.organization)

--- a/bom/tests.py
+++ b/bom/tests.py
@@ -149,8 +149,9 @@ class TestBOM(TransactionTestCase):
     def test_part_revision_export_bom(self):
         (p1, p2, p3, p4) = create_some_fake_parts(organization=self.organization)
 
-        response = self.client.post(reverse('bom:part-revision-export-bom', kwargs={'part_revision_id': p1.latest().id}))
-        self.assertEqual(response.status_code, 200)
+        for part in [p1, p2, p3, p4]:
+            response = self.client.post(reverse('bom:part-revision-export-bom', kwargs={'part_id': part.latest().id}))
+            self.assertEqual(response.status_code, 200)
 
     def test_part_revision_export_bom_flat(self):
         (p1, p2, p3, p4) = create_some_fake_parts(organization=self.organization)

--- a/bom/tests.py
+++ b/bom/tests.py
@@ -142,20 +142,9 @@ class TestBOM(TransactionTestCase):
     def test_part_export_bom(self):
         (p1, p2, p3, p4) = create_some_fake_parts(organization=self.organization)
 
-        response = self.client.post(reverse('bom:part-export-bom', kwargs={'part_id': p1.id}))
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.post(reverse('bom:part-export-bom-sourcing', kwargs={'part_id': p1.id}))
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.post(reverse('bom:part-export-bom-sourcing-detailed', kwargs={'part_id': p1.id}))
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.post(reverse('bom:part-revision-export-bom-sourcing', kwargs={'part_revision_id': p3.latest().id}))
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.post(reverse('bom:part-revision-export-bom-sourcing-detailed', kwargs={'part_revision_id': p3.latest().id}))
-        self.assertEqual(response.status_code, 200)
+        for part in [p1, p2, p3, p4]:
+            response = self.client.post(reverse('bom:part-export-bom', kwargs={'part_id': part.id}))
+            self.assertEqual(response.status_code, 200)
 
     def test_part_revision_export_bom(self):
         (p1, p2, p3, p4) = create_some_fake_parts(organization=self.organization)
@@ -166,14 +155,9 @@ class TestBOM(TransactionTestCase):
     def test_part_revision_export_bom_flat(self):
         (p1, p2, p3, p4) = create_some_fake_parts(organization=self.organization)
 
-        response = self.client.post(reverse('bom:part-revision-export-bom-flat', kwargs={'part_revision_id': p1.latest().id}))
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.post(reverse('bom:part-revision-export-bom-flat-sourcing', kwargs={'part_revision_id': p1.latest().id}))
-        self.assertEqual(response.status_code, 200)
-
-        response = self.client.post(reverse('bom:part-revision-export-bom-flat-sourcing-detailed', kwargs={'part_revision_id': p1.latest().id}))
-        self.assertEqual(response.status_code, 200)
+        for part in [p1, p2, p3, p4]:
+            response = self.client.post(reverse('bom:part-revision-export-bom-flat', kwargs={'part_revision_id': part.latest().id}))
+            self.assertEqual(response.status_code, 200)
 
     def test_export_parts(self):
         (p1, p2, p3, p4) = create_some_fake_parts(organization=self.organization)
@@ -522,21 +506,6 @@ class TestBOM(TransactionTestCase):
         self.assertTrue('error' in str(response.content))
         self.assertTrue('already in use' in str(response.content))
 
-    def test_unique_indented_part_ids(self):
-        org = self.organization
-        pc = PartClass(code=1, name="CoolName", organization=org)
-        pc.save()
-        p = Part(number_item=('A' * org.number_item_len), organization=org, number_class=pc)
-        p.save()
-        m = Manufacturer(name="MyMan", organization=org)
-        m.save()
-        mp = ManufacturerPart(part=p, manufacturer=m, manufacturer_part_number="A1234321")
-        mp.save()
-        p.primary_manufacturer_part = mp
-        p.save()
-        pr = PartRevision(part=p, revision="1")
-        pr.save()
-        print(pr)
 
     def test_create_part_no_manufacturer_part(self):
         (p1, p2, p3, p4) = create_some_fake_parts(organization=self.organization)

--- a/bom/urls.py
+++ b/bom/urls.py
@@ -34,8 +34,6 @@ bom_patterns = [
     path('upload-bom/', views.upload_bom, name='upload-bom'),
     path('part/<int:part_id>/', views.part_info, name='part-info'),
     path('part/<int:part_id>/export/', views.part_export_bom, name='part-export-bom'),
-    path('part/<int:part_id>/export-sourcing/', views.part_export_bom, name='part-export-bom-sourcing', kwargs={'sourcing': True}),
-    path('part/<int:part_id>/export-sourcing-detailed/', views.part_export_bom, name='part-export-bom-sourcing-detailed', kwargs={'sourcing_detailed': True}),
     path('part/<int:part_id>/upload/', views.part_upload_bom, name='part-upload-bom'),
     path('part/<int:part_id>/edit/', views.part_edit, name='part-edit'),
     path('part/<int:part_id>/delete/', views.part_delete, name='part-delete'),
@@ -53,11 +51,7 @@ bom_patterns = [
     path('part/<int:part_id>/rev/<int:part_revision_id>/add-subpart/', views.add_subpart, name='part-add-subpart'),
 
     path('part-rev/<int:part_revision_id>/export/', views.part_export_bom, name='part-revision-export-bom'),
-    path('part-rev/<int:part_revision_id>/export-sourcing/', views.part_export_bom, name='part-revision-export-bom-sourcing', kwargs={'sourcing': True}),
-    path('part-rev/<int:part_revision_id>/export-sourcing-detailed/', views.part_export_bom, name='part-revision-export-bom-sourcing-detailed', kwargs={'sourcing_detailed': True}),
     path('part-rev/<int:part_revision_id>/export-flat/', views.part_export_bom, name='part-revision-export-bom-flat', kwargs={'flat': True}),
-    path('part-rev/<int:part_revision_id>/export-flat-sourcing/', views.part_export_bom, name='part-revision-export-bom-flat-sourcing', kwargs={'flat': True, 'sourcing': True}),
-    path('part-rev/<int:part_revision_id>/export-flat-sourcing-detailed/', views.part_export_bom, name='part-revision-export-bom-flat-sourcing-detailed', kwargs={'flat': True, 'sourcing_detailed': True}),
 
     path('sellerpart/<int:sellerpart_id>/edit/', views.sellerpart_edit, name='sellerpart-edit'),
     path('sellerpart/<int:sellerpart_id>/delete/', views.sellerpart_delete, name='sellerpart-delete'),

--- a/bom/views/views.py
+++ b/bom/views/views.py
@@ -837,10 +837,10 @@ def part_export_bom(request, part_id=None, part_revision_id=None, flat=False):
             bom = part_revision.indented(top_level_quantity=qty)
     except (RuntimeError, RecursionError):
         messages.error(request, "Error: infinite recursion in part relationship. Contact info@indabom.com to resolve.")
-        bom = []
+        return response
     except AttributeError as err:
         messages.error(request, err)
-        bom = []
+        return response
 
     if flat:
         csv_headers = BOMFlatCSVHeaders()

--- a/bom/views/views.py
+++ b/bom/views/views.py
@@ -3,6 +3,7 @@ import logging
 import operator
 from functools import reduce
 from json import dumps
+from typing import List
 
 from django.conf import settings
 from django.contrib import messages
@@ -27,7 +28,6 @@ import bom.constants as constants
 from bom.csv_headers import (
     BOMFlatCSVHeaders,
     BOMIndentedCSVHeaders,
-    ManufacturerPartCSVHeaders,
     PartClassesCSVHeaders,
     SellerPartCSVHeaders,
 )
@@ -78,7 +78,7 @@ from bom.utils import check_references_for_duplicates, listify_string, prep_for_
 logger = logging.getLogger(__name__)
 BOM_LOGIN_URL = getattr(settings, "BOM_LOGIN_URL", None) or settings.LOGIN_URL
 
-def form_error_messages(form_errors) -> [str]:
+def form_error_messages(form_errors) -> List[str]:
     error_messages = []
     for k, errors in form_errors.as_data().items():
         for error_message in errors:
@@ -804,7 +804,7 @@ def part_info(request, part_id, part_revision_id=None):
 
 
 @login_required(login_url=BOM_LOGIN_URL)
-def part_export_bom(request, part_id=None, part_revision_id=None, flat=False, sourcing=False, sourcing_detailed=False):
+def part_export_bom(request, part_id=None, part_revision_id=None, flat=False):
     user = request.user
     profile = user.bom_profile()
     organization = profile.organization
@@ -853,20 +853,8 @@ def part_export_bom(request, part_id=None, part_revision_id=None, flat=False, so
         mapped_row = {}
         raw_row = {k: smart_str(v) for k, v in item.as_dict_for_export().items()}
         for kx, vx in raw_row.items():
-            if csv_headers.get_default(kx) is None: print ("NONE", kx)
+            if csv_headers.get_default(kx) is None: print("NONE", kx)
             mapped_row.update({csv_headers.get_default(kx): vx})
-
-        if sourcing_detailed:
-            for idx, sp in enumerate(item.seller_parts_for_export()):
-                if f'{ManufacturerPartCSVHeaders.all_headers_defns[0]}_{idx + 1}' not in csv_headers_raw:
-                    csv_headers_raw.extend([f'{h}_{idx + 1}' for h in ManufacturerPartCSVHeaders.all_headers_defns])
-                    csv_headers_raw.extend([f'{h}_{idx + 1}' for h in SellerPartCSVHeaders.all_headers_defns])
-                mapped_row.update({f'{k}_{idx + 1}': smart_str(v) for k, v in sp.items()})
-        elif sourcing:
-            for idx, mp in enumerate(item.manufacturer_parts_for_export()):
-                if f'{ManufacturerPartCSVHeaders.all_headers_defns[0]}_{idx + 1}' not in csv_headers_raw:
-                    csv_headers_raw.extend([f'{h}_{idx + 1}' for h in ManufacturerPartCSVHeaders.all_headers_defns])
-                mapped_row.update({f'{k}_{idx + 1}': smart_str(v) for k, v in mp.items()})
 
         csv_rows.append(mapped_row)
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],


### PR DESCRIPTION
This PR adds some improvements requested for H001 BOM:

* removes the Sourcing, Sourcing (Detailed) options for exported BOMs, because they are just duplicating fields....
* Adds a default value to the NRE cost, so that it's not required to enter manually
* Adds a new `lead_time_weeks` at Matt's request

Also I updated the tests to use python3.10, as that's what we're actually deploying